### PR TITLE
TaskList is optional on ScheduleActivityTaskDecisionAttributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 *.iml
 .idea
+.test

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -28,7 +28,7 @@ func TestFSM(t *testing.T) {
 				ScheduleActivityTaskDecisionAttributes: &ScheduleActivityTaskDecisionAttributes{
 					ActivityId:   uuid.New(),
 					ActivityType: ActivityType{Name: "activity", Version: "activityVersion"},
-					TaskList:     TaskList{Name: "taskList"},
+					TaskList:     &TaskList{Name: "taskList"},
 					Input:        serialized,
 				},
 			}
@@ -60,7 +60,7 @@ func TestFSM(t *testing.T) {
 					ScheduleActivityTaskDecisionAttributes: &ScheduleActivityTaskDecisionAttributes{
 						ActivityId:   uuid.New(),
 						ActivityType: ActivityType{Name: "activity", Version: "activityVersion"},
-						TaskList:     TaskList{Name: "taskList"},
+						TaskList:     &TaskList{Name: "taskList"},
 						Input:        serialized,
 					},
 				}

--- a/protocol.go
+++ b/protocol.go
@@ -784,7 +784,7 @@ type ScheduleActivityTaskDecisionAttributes struct {
 	ScheduleToCloseTimeout string       `json:"scheduleToCloseTimeout,omitempty"`
 	ScheduleToStartTimeout string       `json:"scheduleToStartTimeout,omitempty"`
 	StartToCloseTimeout    string       `json:"startToCloseTimeout,omitempty"`
-	TaskList               TaskList     `json:"taskList,omitempty"`
+	TaskList               *TaskList    `json:"taskList,omitempty"`
 }
 
 // SignalExternalWorkflowExecutionDecisionAttributes models the swf json protocol.


### PR DESCRIPTION
http://docs.aws.amazon.com/amazonswf/latest/apireference/API_ScheduleActivityTaskDecisionAttributes.html

Make it a pointer, so it can be nil (and `json:",omitempty"` can do the right thing).

In its current state, calls to the AWS API with empty task listts fail, because an empty TaskList struct is being serialized on the request:

```
2014/10/29 22:13:50 component=FSM name= action=tick at=decide-request-failed error=com.amazon.coral.validate#ValidationException: 1 validation error detected: Value '' at 'decisions.2.member.scheduleActivityTaskDecisionAttributes.taskList.name' failed to satisfy constraint: Member must have length greater than or equal to 1
```
